### PR TITLE
Add configuration to limit messages to apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## [1.1.0] - 2019-06-06
+### Added
+- Configuration (optional) for `application_filter`; if present only send messages to applications in the list
+
+## [1.0.0] - 2019-01-02
+### Added
+- Initial release
+
+[1.1.0]: https://github.com/lucas-nelson/ex_logger_mock/compare/1.0.0...1.1.0
+[1.0.0]: https://github.com/lucas-nelson/ex_logger_mock/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ config :logger,
   backends: [{ExLoggerMock.Backend, :ex_logger_mock}]
 ```
 
+Some packages, e.g. Rollbax, don't like receiving unexpected messages. You can limit the applications
+that will be sent a message with extra configuration:
+
+```elixir
+config :logger,
+  backends: [{ExLoggerMock.Backend, :ex_logger_mock}]
+
+config :ex_logger_mock, application_filter: [:my_app, :my_app_web]
+```
+
 ## Use
 
 The log calls themselves do not change. Without the `:console` backend, you won't see log output

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule ExLoggerMock.MixProject do
       source_url: "https://github.com/lucas-nelson/ex_logger_mock",
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
-      version: "1.0.0"
+      version: "1.1.0"
     ]
   end
 


### PR DESCRIPTION
Add an optional `:application_filter` configuration. If set to a list of atoms, only log messages from an application in the list will be sent back the ex_logger_mock message. All other log messages will be silently dropped.